### PR TITLE
Add display name and theme colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "levelup",
+  "displayName": "Level Up",
   "theme": "ui",
   "version": "0.0.1",
   "description": "The Level Up Tutorials Theme",

--- a/styles/theme-colors.less
+++ b/styles/theme-colors.less
@@ -1,0 +1,1 @@
+@toolbar-background-color: white;


### PR DESCRIPTION
Hey, @stolinski! I'm part of the Nylas team, and we're about to land a new visual theme picker that'll allow people to preview and view color palettes for themes. We pull a few major colors from the theme's UI variables to create the palette, but we've also added a way to override them manually with a `theme-colors.less` file for themes (like yours) that aren't conveyed as well with the variables we selected.

Here's how it looks:
<img width="109" alt="screen shot 2016-03-03 at 2 34 26 pm" src="https://cloud.githubusercontent.com/assets/8452682/13512082/7a42e29a-e14d-11e5-8011-ecdabeab3d42.png">
